### PR TITLE
Crashing on API version 24 and below fixed

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="19" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="19" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="19" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/example/expensemonitor/MainActivity.java
+++ b/app/src/main/java/com/example/expensemonitor/MainActivity.java
@@ -62,9 +62,9 @@ public class MainActivity extends AppCompatActivity {
 
 
             Cursor cursor = null;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                cursor = getContentResolver().query(sms, null, null, null);
-            }
+            //if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                cursor = getContentResolver().query(sms, null, null, null, null);
+            //}
             cursor.moveToFirst();
 
 //            long datetime = cursor.getLong(cursor.getColumnIndexOrThrow("date"));


### PR DESCRIPTION
Changed the .query() method signature to use .query() method introduced in API 1 instead of the .query() method introduced in api 26